### PR TITLE
feat: #33 - Navigation to Personal Settings

### DIFF
--- a/__mocks__/next-image.js
+++ b/__mocks__/next-image.js
@@ -1,0 +1,7 @@
+const React = require('react');
+
+function Image({ src, alt, width, height, className, ...rest }) {
+  return React.createElement('img', { src, alt, width, height, className, ...rest });
+}
+
+module.exports = { __esModule: true, default: Image };

--- a/__mocks__/next-link.js
+++ b/__mocks__/next-link.js
@@ -1,0 +1,7 @@
+const React = require('react');
+
+function Link({ href, children, className, ...rest }) {
+  return React.createElement('a', { href, className, ...rest }, children);
+}
+
+module.exports = { __esModule: true, default: Link };

--- a/app/app/settings/page.tsx
+++ b/app/app/settings/page.tsx
@@ -3,6 +3,7 @@ import { getUserProfile } from '@/lib/db/queries';
 import UserNav from '@/components/UserNav';
 import SettingsForm from '@/components/SettingsForm';
 import { redirect } from 'next/navigation';
+import Link from 'next/link';
 
 export default async function SettingsPage() {
   // Get authenticated user
@@ -31,6 +32,12 @@ export default async function SettingsPage() {
       {/* Settings Content */}
       <div className="mx-auto max-w-4xl px-4 py-8">
         <div className="mb-8">
+          <Link
+            href="/"
+            className="mb-6 inline-flex items-center text-sm text-zinc-600 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-50"
+          >
+            ← Dashboard
+          </Link>
           <h1 className="mb-2 text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
             Settings
           </h1>

--- a/app/components/UserNav.tsx
+++ b/app/components/UserNav.tsx
@@ -1,5 +1,6 @@
 import { auth, signOut } from "@/auth"
 import Image from "next/image"
+import Link from "next/link"
 
 export default async function UserNav() {
   const session = await auth()
@@ -26,6 +27,13 @@ export default async function UserNav() {
           className="rounded-full border-2 border-zinc-200 dark:border-zinc-800"
         />
       )}
+
+      <Link
+        href="/settings"
+        className="rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-medium text-zinc-900 transition-colors hover:bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-50 dark:hover:bg-zinc-800"
+      >
+        Settings
+      </Link>
 
       <form
         action={async () => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,8 @@ module.exports = {
   testMatch: ['**/__tests__/**/*.ts?(x)', '**/?(*.)+(spec|test).ts?(x)'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/app/$1',
+    '^next/link$': '<rootDir>/__mocks__/next-link.js',
+    '^next/image$': '<rootDir>/__mocks__/next-image.js',
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   collectCoverageFrom: [

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -16,14 +16,7 @@ jest.mock('next/navigation', () => ({
   useParams: jest.fn(() => ({})),
 }))
 
-// Mock Next.js Image component
-jest.mock('next/image', () => ({
-  __esModule: true,
-  default: function Image(props) {
-    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
-    return require('react').createElement('img', props)
-  },
-}))
+// next/link and next/image are mapped to stubs via moduleNameMapper in jest.config.js
 
 // Mock Auth.js
 jest.mock('./app/auth', () => ({

--- a/tests/components/UserNav.test.tsx
+++ b/tests/components/UserNav.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react';
+import UserNav from '@/components/UserNav';
+import { auth } from '@/auth';
+
+const mockedAuth = auth as jest.MockedFunction<typeof auth>;
+
+describe('UserNav', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing when not authenticated', async () => {
+    mockedAuth.mockResolvedValue(null);
+
+    const { container } = render(await UserNav());
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders Settings link for authenticated users', async () => {
+    mockedAuth.mockResolvedValue({
+      user: {
+        name: 'Test User',
+        email: 'test@example.com',
+        image: null,
+      },
+    });
+
+    render(await UserNav());
+
+    const settingsLink = screen.getByRole('link', { name: 'Settings' });
+    expect(settingsLink).toBeInTheDocument();
+    expect(settingsLink).toHaveAttribute('href', '/settings');
+  });
+
+  it('renders Sign Out button for authenticated users', async () => {
+    mockedAuth.mockResolvedValue({
+      user: {
+        name: 'Test User',
+        email: 'test@example.com',
+        image: null,
+      },
+    });
+
+    render(await UserNav());
+
+    expect(screen.getByRole('button', { name: 'Sign Out' })).toBeInTheDocument();
+  });
+
+  it('renders user name and email for authenticated users', async () => {
+    mockedAuth.mockResolvedValue({
+      user: {
+        name: 'Test User',
+        email: 'test@example.com',
+        image: null,
+      },
+    });
+
+    render(await UserNav());
+
+    expect(screen.getByText('Test User')).toBeInTheDocument();
+    expect(screen.getByText('test@example.com')).toBeInTheDocument();
+  });
+
+  it('renders avatar when user has an image', async () => {
+    mockedAuth.mockResolvedValue({
+      user: {
+        name: 'Test User',
+        email: 'test@example.com',
+        image: 'https://example.com/avatar.jpg',
+      },
+    });
+
+    render(await UserNav());
+
+    const avatar = screen.getByRole('img', { name: 'Test User' });
+    expect(avatar).toBeInTheDocument();
+    expect(avatar).toHaveAttribute('src', 'https://example.com/avatar.jpg');
+  });
+});


### PR DESCRIPTION
## Summary
Closes #33

Provides bidirectional navigation between the main dashboard and the settings page so users can easily access and return from their personal configuration.

## Implementation
- Added a **Settings** link to `UserNav` — visible only to authenticated users, appears in the top-right corner of every page via the root layout
- Added a **← Dashboard** link to the settings page header for easy return navigation
- Added `UserNav` unit tests covering the Settings link, auth states, and user info rendering
- Added `next/link` and `next/image` stub mocks via `moduleNameMapper` in `jest.config.js` to resolve React version mismatch in tests

## Plan
Implementation plan: `plans/issue-33-adw-20260218034725-sdlc_planner-settings-navigation.md`

## Testing
- 67 unit tests pass (`npm test`)
- ESLint passes (`npm run lint`)
- TypeScript type check passes (`npx tsc --noEmit`)
- Production build passes (`npm run build`)

## Metadata
- ADW ID: `1771386622`
- Issue: #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)