### PR TITLE
bug: #36 - Duplicate User Profile and Logout section in Settings page

### DIFF
--- a/app/app/settings/page.tsx
+++ b/app/app/settings/page.tsx
@@ -1,7 +1,6 @@
 import { getCurrentUser } from '@/lib/auth';
 import { getUserProfile } from '@/lib/db/queries';
 import { upsertUser } from '@/lib/db/mutations';
-import UserNav from '@/components/UserNav';
 import SettingsForm from '@/components/SettingsForm';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
@@ -27,13 +26,6 @@ export default async function SettingsPage() {
 
   return (
     <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950">
-      {/* User Navigation */}
-      <div className="border-b border-zinc-200 bg-white dark:border-zinc-800 dark:bg-zinc-900">
-        <div className="mx-auto max-w-7xl px-4 py-4">
-          <UserNav />
-        </div>
-      </div>
-
       {/* Settings Content */}
       <div className="mx-auto max-w-4xl px-4 py-8">
         <div className="mb-8">

--- a/tests/app/settings/page.test.tsx
+++ b/tests/app/settings/page.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import SettingsPage from '@/app/settings/page';
+import { getCurrentUser } from '@/lib/auth';
+import { getUserProfile } from '@/lib/db/queries';
+import type { User } from '@/lib/db/schema';
+
+jest.mock('@/lib/auth');
+jest.mock('@/lib/db/connection', () => ({ db: {} }));
+jest.mock('@/lib/db/queries');
+jest.mock('@/lib/db/mutations');
+jest.mock('next/navigation', () => ({ redirect: jest.fn() }));
+jest.mock('@/auth', () => ({ auth: jest.fn(), signOut: jest.fn() }));
+jest.mock('@/components/UserNav', () => () => <div data-testid="user-nav" />);
+jest.mock('@/components/SettingsForm', () => () => <div data-testid="settings-form" />);
+
+const mockGetCurrentUser = getCurrentUser as jest.MockedFunction<typeof getCurrentUser>;
+const mockGetUserProfile = getUserProfile as jest.MockedFunction<typeof getUserProfile>;
+
+const mockUser: User = {
+  id: 'user-1',
+  email: 'test@example.com',
+  name: 'Test User',
+  image: null,
+  maxTasks: 3,
+  createdAt: new Date('2024-01-01'),
+};
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not render UserNav directly (prevents duplicate nav)', async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: 'user-1', email: 'test@example.com', name: 'Test User' });
+    mockGetUserProfile.mockResolvedValue(mockUser);
+
+    render(await SettingsPage());
+
+    // The settings page itself should NOT render UserNav
+    // (UserNav is already rendered by the root layout globally)
+    expect(screen.queryByTestId('user-nav')).not.toBeInTheDocument();
+  });
+
+  it('renders the Settings heading', async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: 'user-1', email: 'test@example.com', name: 'Test User' });
+    mockGetUserProfile.mockResolvedValue(mockUser);
+
+    render(await SettingsPage());
+
+    expect(screen.getByRole('heading', { name: 'Settings' })).toBeInTheDocument();
+  });
+
+  it('renders the Dashboard back link', async () => {
+    mockGetCurrentUser.mockResolvedValue({ id: 'user-1', email: 'test@example.com', name: 'Test User' });
+    mockGetUserProfile.mockResolvedValue(mockUser);
+
+    render(await SettingsPage());
+
+    const dashboardLink = screen.getByRole('link', { name: /dashboard/i });
+    expect(dashboardLink).toHaveAttribute('href', '/');
+  });
+});


### PR DESCRIPTION
## Summary
Closes #36

The `UserNav` component (user name, email, avatar, Settings link, Sign Out button) was rendering twice on the `/settings` page: once from the root layout's fixed global header, and once from the settings page's own page-level header bar.

## Implementation
- Remove the `UserNav` import from `settings/page.tsx`
- Remove the redundant border-bottom header `<div>` block containing `<UserNav />` from the settings page — the root `layout.tsx` already renders it globally on every page
- Add `tests/app/settings/page.test.tsx` with a regression test that asserts `UserNav` is not rendered directly by the settings page, plus tests for the heading and back link

## Plan
Implementation plan: `plans/issue-36-adw-1771414846-sdlc_planner-fix-duplicate-usernav-settings.md`

## Testing
- 88 tests passing (`npx jest` from project root)
- TypeScript type check clean (`npx tsc --noEmit`)
- Production build succeeds (`npm run build`)
- New regression test confirms `UserNav` is not rendered by the settings page component itself

## Metadata
- ADW ID: `1771414956`
- Issue: #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)