### PR TITLE
bug: #47 - Hardcoded task limit of 3 on login page and layout metadata

### DIFF
--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -15,7 +15,7 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   title: "Pick Your Battles",
-  description: "A minimalist productivity tool that enforces focus by limiting users to 3 concurrent tasks.",
+  description: "A minimalist productivity tool that enforces focus by limiting users to a configurable number of concurrent tasks.",
 };
 
 export default function RootLayout({

--- a/app/app/login/page.tsx
+++ b/app/app/login/page.tsx
@@ -10,7 +10,7 @@ export default function LoginPage() {
             Pick Your Battles
           </h1>
           <p className="text-lg text-zinc-600 dark:text-zinc-400">
-            Focus on what matters. Limit yourself to 3 tasks at a time.
+            Focus on what matters. Limit yourself to a few tasks at a time.
           </p>
         </div>
 

--- a/tests/app/login/page.test.tsx
+++ b/tests/app/login/page.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import LoginPage from '@/app/login/page';
+
+jest.mock('@/auth', () => ({ signIn: jest.fn() }));
+
+describe('LoginPage', () => {
+  it('does not show hardcoded task limit of 3 in tagline', () => {
+    render(<LoginPage />);
+
+    expect(screen.queryByText(/limit yourself to 3 tasks/i)).not.toBeInTheDocument();
+  });
+
+  it('renders app name', () => {
+    render(<LoginPage />);
+
+    expect(screen.getByRole('heading', { name: 'Pick Your Battles' })).toBeInTheDocument();
+  });
+
+  it('renders sign in button', () => {
+    render(<LoginPage />);
+
+    expect(screen.getByRole('button', { name: /sign in with google/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
Closes #47

The login page tagline and the root layout SEO meta description both hardcoded "3 tasks" as a fixed limit, contradicting the app's configurable task limit feature established in bug #40.

## Implementation
- Update `app/app/login/page.tsx` tagline: `"Limit yourself to 3 tasks at a time."` → `"Limit yourself to a few tasks at a time."` — matches the copy pattern from `LandingPage.tsx`
- Update `app/app/layout.tsx` meta description: `"limiting users to 3 concurrent tasks"` → `"limiting users to a configurable number of concurrent tasks"` — accurate for SEO/link previews
- Add `tests/app/login/page.test.tsx` with a regression test that asserts the hardcoded "3 tasks" string no longer appears in the login page tagline

## Plan
Implementation plan: `plans/issue-47-adw-1771415607-sdlc_planner-fix-hardcoded-task-limit-login-layout.md`

## Testing
- 91 tests passing (`npx jest` from project root)
- TypeScript type check clean (`npx tsc --noEmit`)
- Production build succeeds (`npm run build`)
- Regression test written first (confirmed failing), then fixed (confirmed passing)

## Metadata
- ADW ID: `1771415669`
- Issue: #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)