### PR TITLE
chore: #49 - Add pointer cursor on hover for interactive buttons and task actions

### DIFF
--- a/app/app/login/page.tsx
+++ b/app/app/login/page.tsx
@@ -30,7 +30,7 @@ export default function LoginPage() {
           >
             <button
               type="submit"
-              className="flex w-full items-center justify-center gap-3 rounded-lg bg-zinc-900 px-6 py-3 font-medium text-white transition-colors hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+              className="flex w-full cursor-pointer items-center justify-center gap-3 rounded-lg bg-zinc-900 px-6 py-3 font-medium text-white transition-colors hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
             >
               <svg className="h-5 w-5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                 <path

--- a/app/components/LandingPage.tsx
+++ b/app/components/LandingPage.tsx
@@ -113,7 +113,7 @@ export default function LandingPage() {
           >
             <button
               type="submit"
-              className="inline-flex items-center gap-3 rounded-lg bg-zinc-900 px-8 py-4 text-lg font-medium text-white transition-colors hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+              className="inline-flex cursor-pointer items-center gap-3 rounded-lg bg-zinc-900 px-8 py-4 text-lg font-medium text-white transition-colors hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
             >
               <svg className="h-6 w-6" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                 <path

--- a/app/components/SettingsForm.tsx
+++ b/app/components/SettingsForm.tsx
@@ -93,7 +93,7 @@ export default function SettingsForm({
         <button
           type="submit"
           disabled={isLoading}
-          className="inline-flex justify-center rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-zinc-800 focus:outline-none focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200 dark:focus:ring-zinc-50"
+          className="inline-flex cursor-pointer justify-center rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-zinc-800 focus:outline-none focus:ring-2 focus:ring-zinc-900 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200 dark:focus:ring-zinc-50"
         >
           {isLoading ? 'Saving...' : 'Save Settings'}
         </button>

--- a/app/components/TaskSlot.tsx
+++ b/app/components/TaskSlot.tsx
@@ -73,7 +73,7 @@ export default function TaskSlot({
               <button
                 type="submit"
                 disabled={!newTitle.trim() || isSubmitting}
-                className="flex-1 rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+                className="flex-1 cursor-pointer rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-zinc-800 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
               >
                 {isSubmitting ? 'Adding...' : 'Add'}
               </button>
@@ -81,7 +81,7 @@ export default function TaskSlot({
                 type="button"
                 onClick={handleCancel}
                 disabled={isSubmitting}
-                className="rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-900 transition-colors hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-50 dark:hover:bg-zinc-700"
+                className="cursor-pointer rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm font-medium text-zinc-900 transition-colors hover:bg-zinc-50 disabled:opacity-50 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-50 dark:hover:bg-zinc-700"
               >
                 Cancel
               </button>
@@ -104,7 +104,7 @@ export default function TaskSlot({
           {onAddTask && !isFocusMode ? (
             <button
               onClick={() => setIsAdding(true)}
-              className="flex flex-col items-center gap-2 text-zinc-400 transition-colors hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300"
+              className="flex cursor-pointer flex-col items-center gap-2 text-zinc-400 transition-colors hover:text-zinc-600 dark:text-zinc-500 dark:hover:text-zinc-300"
               aria-label={`Add task to slot ${slotNumber}`}
             >
               <span className="text-3xl font-light leading-none">+</span>
@@ -145,7 +145,7 @@ export default function TaskSlot({
           {onFocusToggle && (
             <button
               onClick={() => onFocusToggle(task.id)}
-              className="rounded p-1 hover:bg-zinc-100 dark:hover:bg-zinc-800"
+              className="cursor-pointer rounded p-1 hover:bg-zinc-100 dark:hover:bg-zinc-800"
               aria-label={isFocused ? 'Unfocus task' : 'Focus on this task'}
               title={isFocused ? 'Exit focus mode' : 'Focus on this task'}
             >

--- a/app/components/UserNav.tsx
+++ b/app/components/UserNav.tsx
@@ -43,7 +43,7 @@ export default async function UserNav() {
       >
         <button
           type="submit"
-          className="rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-medium text-zinc-900 transition-colors hover:bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-50 dark:hover:bg-zinc-800"
+          className="cursor-pointer rounded-lg border border-zinc-200 bg-white px-4 py-2 text-sm font-medium text-zinc-900 transition-colors hover:bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-50 dark:hover:bg-zinc-800"
         >
           Sign Out
         </button>

--- a/tests/components/TaskSlot.test.tsx
+++ b/tests/components/TaskSlot.test.tsx
@@ -62,6 +62,12 @@ describe('TaskSlot Component', () => {
       expect(screen.getByText('Add Task')).toBeInTheDocument()
     })
 
+    it('Add Task button has cursor-pointer class', () => {
+      render(<TaskSlot slotNumber={1} onAddTask={jest.fn()} />)
+
+      expect(screen.getByLabelText('Add task to slot 1')).toHaveClass('cursor-pointer')
+    })
+
     it('does not render Add Task button when onAddTask not provided', () => {
       render(<TaskSlot slotNumber={1} />)
 
@@ -141,6 +147,19 @@ describe('TaskSlot Component', () => {
       createdAt: new Date(),
       updatedAt: new Date(),
     }
+
+    it('focus toggle button has cursor-pointer class', () => {
+      render(
+        <TaskSlot
+          slotNumber={1}
+          task={mockTask}
+          focusedTaskId={null}
+          onFocusToggle={jest.fn()}
+        />
+      )
+
+      expect(screen.getByLabelText(/Focus on this task/)).toHaveClass('cursor-pointer')
+    })
 
     it('renders focus button when onFocusToggle provided', () => {
       const mockOnFocusToggle = jest.fn()

--- a/tests/components/UserNav.test.tsx
+++ b/tests/components/UserNav.test.tsx
@@ -47,6 +47,20 @@ describe('UserNav', () => {
     expect(screen.getByRole('button', { name: 'Sign Out' })).toBeInTheDocument();
   });
 
+  it('Sign Out button has cursor-pointer class', async () => {
+    mockedAuth.mockResolvedValue({
+      user: {
+        name: 'Test User',
+        email: 'test@example.com',
+        image: null,
+      },
+    });
+
+    render(await UserNav());
+
+    expect(screen.getByRole('button', { name: 'Sign Out' })).toHaveClass('cursor-pointer');
+  });
+
   it('renders user name and email for authenticated users', async () => {
     mockedAuth.mockResolvedValue({
       user: {


### PR DESCRIPTION
## Summary
Closes #49

Added `cursor-pointer` Tailwind class to all 8 interactive `<button>` elements in the app that were missing it. Browsers do not apply a hand cursor to buttons by default (only to `<a>` tags), making it unclear to users that these elements are clickable.

## Implementation
- **`app/components/TaskSlot.tsx`** — 4 buttons updated: Add submit, Cancel, "Add Task" empty-slot button, focus toggle button
- **`app/components/UserNav.tsx`** — Sign Out button
- **`app/components/LandingPage.tsx`** — CTA "Sign in with Google" button
- **`app/app/login/page.tsx`** — "Sign in with Google" button
- **`app/components/SettingsForm.tsx`** — Save Settings button
- Buttons with `disabled:cursor-not-allowed` retain correct override behaviour (Tailwind's `disabled:` variant takes precedence)
- Added regression tests to `TaskSlot.test.tsx` (Add Task button, focus toggle) and `UserNav.test.tsx` (Sign Out button) asserting `cursor-pointer` class is present

## Plan
Implementation plan: `plans/issue-49-adw-1771416324-sdlc_planner-add-pointer-cursor-buttons.md`

## Testing
- 94 tests passing (`npx jest` from project root)
- TypeScript type check clean (`npx tsc --noEmit`)
- Production build succeeds (`npm run build`)

## Metadata
- ADW ID: `1771416417`
- Issue: #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)