### PR TITLE
bug: #51 - Task creation fails with 500 User not found due to missing email fallback in createTask

### DIFF
--- a/app/app/api/tasks/route.ts
+++ b/app/app/api/tasks/route.ts
@@ -59,7 +59,7 @@ export async function POST(request: NextRequest) {
       description: body.description || null,
       position: body.position,
       status: body.status || 'pending',
-    });
+    }, session.user.email ?? undefined);
 
     return NextResponse.json(task, { status: 201 });
   } catch (error) {

--- a/app/lib/db/mutations.ts
+++ b/app/lib/db/mutations.ts
@@ -34,10 +34,11 @@ export async function upsertUser(data: InsertUser): Promise<User> {
  */
 export async function createTask(
   userId: string,
-  data: Omit<InsertTask, 'userId'>
+  data: Omit<InsertTask, 'userId'>,
+  email?: string
 ): Promise<Task> {
   // Get user profile to check their personal task limit
-  const user = await getUserProfile(userId);
+  const user = await getUserProfile(userId, email);
   if (!user) {
     throw new Error('User not found');
   }


### PR DESCRIPTION
## Summary
Closes #51

Task creation was returning 500 "User not found" when the user's OAuth ID in their session did not match the stored database ID. The email fallback mechanism in `getUserProfile` was never triggered because `createTask` did not pass the email parameter.

## Implementation
- Added optional `email?: string` parameter to `createTask` in `mutations.ts` and forwarded it to `getUserProfile`
- Updated `POST /api/tasks` route to pass `session.user.email` to `createTask`
- Updated existing test assertion to expect email forwarded as `undefined` when not provided
- Added regression test: `passes email to getUserProfile for OAuth ID fallback`

## Plan
Implementation plan: plans/issue-51-adw-1771418020-sdlc_planner-fix-task-creation-user-not-found.md

## Testing
- 95 tests passing across 11 suites
- New regression test verifies email is forwarded to `getUserProfile`
- ESLint and TypeScript type check clean

## Metadata
- ADW ID: `1771418091`
- Issue: #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)