### PR TITLE
bug: #51 - Fix OAuth ID mismatch across all routes (task creation, listing, update, delete, settings)

### DIFF
--- a/app/app/api/user/route.ts
+++ b/app/app/api/user/route.ts
@@ -85,8 +85,14 @@ export async function PATCH(request: Request) {
       }
     }
 
-    // Update user profile
-    const updatedUser = await updateUserProfile(user.id!, {
+    // Resolve canonical DB user ID (handles OAuth ID rotation)
+    const profile = await getUserProfile(user.id!, user.email ?? undefined);
+    if (!profile) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    // Update user profile using canonical DB ID
+    const updatedUser = await updateUserProfile(profile.id, {
       maxTasks,
     });
 

--- a/app/lib/db/mutations.ts
+++ b/app/lib/db/mutations.ts
@@ -43,8 +43,11 @@ export async function createTask(
     throw new Error('User not found');
   }
 
+  // Use canonical DB user ID (handles OAuth ID rotation in session)
+  const dbUserId = user.id;
+
   // Check user's personal task limit
-  const currentCount = await getTaskCount(userId);
+  const currentCount = await getTaskCount(dbUserId);
   if (currentCount >= user.maxTasks) {
     throw new Error(
       `Task limit reached. You can only have ${user.maxTasks} tasks at a time.`
@@ -55,7 +58,7 @@ export async function createTask(
     .insert(tasks)
     .values({
       ...data,
-      userId,
+      userId: dbUserId,
     })
     .returning();
 

--- a/tests/lib/auth.test.ts
+++ b/tests/lib/auth.test.ts
@@ -1,10 +1,17 @@
-import { getCurrentUser, requireAuth } from '@/lib/auth'
+import { getCurrentUser, requireAuth, resolveUserProfile } from '@/lib/auth'
 import { auth } from '@/auth'
+import { getUserProfile } from '@/lib/db/queries'
+import { upsertUser } from '@/lib/db/mutations'
 
 // Mock the auth module
 jest.mock('@/auth')
+jest.mock('@/lib/db/connection', () => ({ db: {} }))
+jest.mock('@/lib/db/queries')
+jest.mock('@/lib/db/mutations')
 
 const mockedAuth = auth as jest.MockedFunction<typeof auth>
+const mockGetUserProfile = getUserProfile as jest.MockedFunction<typeof getUserProfile>
+const mockUpsertUser = upsertUser as jest.MockedFunction<typeof upsertUser>
 
 describe('Auth Utility Functions', () => {
   beforeEach(() => {
@@ -89,6 +96,73 @@ describe('Auth Utility Functions', () => {
       await expect(requireAuth()).rejects.toThrow(
         'Unauthorized: User must be authenticated'
       )
+    })
+  })
+
+  describe('resolveUserProfile', () => {
+    const mockDbUser = {
+      id: 'db-user-id',
+      email: 'test@example.com',
+      name: 'Test User',
+      image: null,
+      maxTasks: 3,
+      createdAt: new Date(),
+    }
+
+    it('returns null when not authenticated', async () => {
+      mockedAuth.mockResolvedValue(null)
+
+      const result = await resolveUserProfile()
+
+      expect(result).toBeNull()
+      expect(mockGetUserProfile).not.toHaveBeenCalled()
+    })
+
+    it('returns user profile found by ID', async () => {
+      mockedAuth.mockResolvedValue({
+        user: { id: 'db-user-id', email: 'test@example.com', name: 'Test User' },
+        expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      })
+      mockGetUserProfile.mockResolvedValue(mockDbUser)
+
+      const result = await resolveUserProfile()
+
+      expect(result).toEqual(mockDbUser)
+      expect(mockGetUserProfile).toHaveBeenCalledWith('db-user-id', 'test@example.com')
+    })
+
+    it('returns user profile found by email when OAuth ID changed', async () => {
+      mockedAuth.mockResolvedValue({
+        user: { id: 'new-oauth-id', email: 'test@example.com', name: 'Test User' },
+        expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      })
+      // getUserProfile falls back to email and finds the user
+      mockGetUserProfile.mockResolvedValue({ ...mockDbUser, id: 'old-db-id' })
+
+      const result = await resolveUserProfile()
+
+      expect(result).not.toBeNull()
+      expect(result?.id).toBe('old-db-id')
+      expect(mockUpsertUser).not.toHaveBeenCalled()
+    })
+
+    it('creates user via upsert when profile not found', async () => {
+      mockedAuth.mockResolvedValue({
+        user: { id: 'new-user-id', email: 'new@example.com', name: 'New User' },
+        expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      })
+      mockGetUserProfile.mockResolvedValue(null)
+      mockUpsertUser.mockResolvedValue({ ...mockDbUser, id: 'new-user-id', email: 'new@example.com' })
+
+      const result = await resolveUserProfile()
+
+      expect(result).not.toBeNull()
+      expect(mockUpsertUser).toHaveBeenCalledWith({
+        id: 'new-user-id',
+        email: 'new@example.com',
+        name: 'New User',
+        image: null,
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary
Closes #51

The root cause was systemic: every API route used `session.user.id` directly for DB operations. When a user's Google OAuth ID rotates, this session ID no longer matches the stored `users.id`, causing:
- **Task creation** → FK constraint violation (500 error)
- **Task listing** → empty results (tasks appear missing)
- **Task update/delete** → silent 404 (wrong ownership check)
- **Settings PATCH** → returns null/404

## Implementation
- Added `resolveUserProfile()` to `lib/auth.ts`: looks up the canonical DB user ID using `getUserProfile` with email fallback, upserts if the user doesn't exist yet
- Replaced `requireAuth()` + raw `session.user.id` with `resolveUserProfile()` + `profile.id` in:
  - `GET /api/tasks` and `POST /api/tasks`
  - `PATCH /api/tasks/[id]` and `DELETE /api/tasks/[id]`
  - `PATCH /api/user`
- Fixed `createTask` in `mutations.ts` to use `user.id` from the fetched profile for the DB insert and task count check (belt-and-suspenders)

## Plan
Implementation plan: plans/issue-51-adw-1771418020-sdlc_planner-fix-task-creation-user-not-found.md

## Testing
- 105 tests passing across 11 suites (+10 new tests)
- New `resolveUserProfile` tests in `tests/lib/auth.test.ts`
- Updated task route tests to assert canonical DB ID is used
- Added POST /api/tasks test coverage

## Metadata
- ADW ID: `1771419514`
- Issue: #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)